### PR TITLE
Slack Alerts for failures categorized by BFA plugin

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -10,4 +10,5 @@
     <suppress checks=".+"
               files="InjectedTest.java"/>
     <suppress checks="MagicNumber" files="BuildLogIndication.java"/>
+    <suppress checks="HiddenField" files="PluginImpl.java"/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <java.level>8</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.6.6</powermock.version>
         <checkstyle.version>2.13</checkstyle.version>
@@ -96,6 +96,25 @@
                     <!-- Provided by the plugin -->
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.jenkins-ci.plugins/slack -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>slack</artifactId>
+            <version>2.3</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <!-- Provided by the plugin -->
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- Provided by the plugin -->
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>credentials</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/PluginImpl.java
@@ -84,6 +84,16 @@ public class PluginImpl extends Plugin {
     private static final int BYTES_IN_MEGABYTE = 1024 * 1024;
 
     /**
+     * Default slack channel to use.
+     */
+    public static final String DEFAULT_SLACK_CHANNEL =  "";
+
+    /**
+     * Default value for which failure categories to notify slack.
+     */
+    public static final String DEFAULT_SLACK_FAILURE_CATEGORIES = "ALL";
+
+    /**
      * The permission group for all permissions related to this plugin.
      */
     public static final PermissionGroup PERMISSION_GROUP =
@@ -126,6 +136,9 @@ public class PluginImpl extends Plugin {
     private boolean doNotAnalyzeAbortedJob;
 
     private Boolean gerritTriggerEnabled;
+    private Boolean slackNotifEnabled;
+    private String slackChannelName;
+    private String slackFailureCategories;
 
     private transient CopyOnWriteList<FailureCause> causes;
 
@@ -431,12 +444,78 @@ public class PluginImpl extends Plugin {
     }
 
     /**
+     * Send notifications to Slack.
+     *
+     * @return true if on.
+     */
+    public boolean isSlackNotifEnabled() {
+        if (slackNotifEnabled == null) {
+            return false;
+        } else {
+            return slackNotifEnabled;
+        }
+    }
+
+    /**
+     * Get configured slack channel.
+     *
+     * @return String - Slack Channel.
+     */
+    public String getSlackChannelName() {
+        if (slackChannelName == null) {
+            return DEFAULT_SLACK_CHANNEL;
+        } else {
+            return slackChannelName;
+        }
+    }
+
+    /**
+     * Get configured slack failure cause categories.
+     *
+     * @return String - Space separated list of failure cause categories.
+     */
+    public String getSlackFailureCategories() {
+        if (slackFailureCategories == null) {
+            return DEFAULT_SLACK_FAILURE_CATEGORIES;
+        } else {
+            return slackFailureCategories;
+        }
+    }
+
+    /**
      * Sets if this feature is enabled or not. When on, cause descriptions will be forwarded to Gerrit-Trigger-Plugin.
      *
      * @param gerritTriggerEnabled on or off. null == on.
      */
     public void setGerritTriggerEnabled(Boolean gerritTriggerEnabled) {
         this.gerritTriggerEnabled = gerritTriggerEnabled;
+    }
+
+    /**
+     * Sets if this feature is enabled or not. When on, selected failures will be sent to Slack channel.
+     *
+     * @param slackNotifEnabled on or off. null == off.
+     */
+    public void setSlackNotifEnabled(Boolean slackNotifEnabled) {
+        this.slackNotifEnabled = slackNotifEnabled;
+    }
+
+    /**
+     * Set configured slack channel.
+     *
+     * @param slackChannelName null = DEFAULT_SLACK_CHANNEL
+     */
+    public void setSlackChannel(String slackChannelName) {
+        this.slackChannelName = slackChannelName;
+    }
+
+    /**
+     * Set configured slack failure cause categories.
+     *
+     * @param slackFailureCategories - Space seperated list of failure cause categories.
+     */
+    public void setslackFailureCategories(String slackFailureCategories) {
+        this.slackFailureCategories = slackFailureCategories;
     }
 
     /**
@@ -581,12 +660,15 @@ public class PluginImpl extends Plugin {
         globalEnabled = o.getBoolean("globalEnabled");
         doNotAnalyzeAbortedJob = o.optBoolean("doNotAnalyzeAbortedJob", false);
         gerritTriggerEnabled = o.getBoolean("gerritTriggerEnabled");
+        slackNotifEnabled = o.getBoolean("slackNotifEnabled");
         graphsEnabled = o.getBoolean("graphsEnabled");
         testResultParsingEnabled = o.getBoolean("testResultParsingEnabled");
         testResultCategories = o.getString("testResultCategories");
         maxLogSize = o.optInt("maxLogSize");
         int scanThreads = o.getInt("nrOfScanThreads");
         int minSodWorkerThreads = o.getInt("minimumNumberOfWorkerThreads");
+        slackChannelName = o.getString("slackChannelName");
+        slackFailureCategories = o.getString("slackFailureCategories");
         int maxSodWorkerThreads = o.getInt("maximumNumberOfWorkerThreads");
         int thrkeepAliveTime = o.getInt("threadKeepAliveTime");
         int jobShutdownTimeWait = o.getInt("waitForJobShutdownTime");

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProvider.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProvider.java
@@ -1,0 +1,210 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.jenkins.plugins.bfa;
+
+import jenkins.plugins.slack.SlackNotifier;
+import jenkins.plugins.slack.SlackService;
+import jenkins.plugins.slack.StandardSlackService;
+import jenkins.model.Jenkins;
+import java.util.logging.Logger;
+
+import java.io.PrintStream;
+import java.util.logging.Level;
+
+/**
+ * Class that allows BFA to send failure cause messages for each build to Slack.
+ *
+ * @author Johan Cornelissen &lt;j.cornelissen@queensu.ca&gt;
+ */
+public class SlackMessageProvider {
+    private static final Logger logger = Logger.getLogger(SlackMessageProvider.class.getName());
+    private String slackMessageText;
+    private String teamDomain;
+    private String baseUrl;
+    private String room;
+    private String authToken;
+    private boolean botUser;
+    private String authTokenCredentialId;
+
+    /**
+     * Default constructor that uses attributes from Slack Notifier plugin.
+     */
+    SlackMessageProvider() {
+        SlackNotifier.DescriptorImpl slackDesc = getSlackDescriptor();
+        this.teamDomain = slackDesc.getTeamDomain();
+        this.baseUrl = slackDesc.getBaseUrl();
+        this.authToken = slackDesc.getToken();
+        this.botUser = slackDesc.getBotUser();
+        this.authTokenCredentialId = slackDesc.getTokenCredentialId();
+        this.room = slackDesc.getRoom();
+    }
+
+    /**
+     * Constructor that uses custom attributes.
+     * @param teamDomain - Team slack domain (optional if baseUrl specified)
+     * @param baseUrl - Slack url (optional if team domain specified)
+     * @param authToken - Authorization token (optional if authTokenCredentialId specified)
+     * @param botUser - boolean if using bot user.
+     * @param authTokenCredentialId - Authorization credential id (optional if authToken specified)
+     * @param room - Slack channel
+     */
+    SlackMessageProvider(String teamDomain, String baseUrl, String authToken, boolean botUser,
+            String authTokenCredentialId, String room) {
+        this.teamDomain = teamDomain;
+        this.baseUrl = baseUrl;
+        this.authToken = authToken;
+        this.botUser = botUser;
+        this.authTokenCredentialId = authTokenCredentialId;
+        this.room = room;
+    }
+
+    /**
+     * Get descriptor for Slack Notifier plugin.
+     * @return Descriptor
+     */
+    private SlackNotifier.DescriptorImpl getSlackDescriptor(){
+        return (SlackNotifier.DescriptorImpl)Jenkins.getInstance().getDescriptor(SlackNotifier.class);
+    }
+
+    /**
+     * Retrieve latest set Slack bot user.
+     * @return String of slack bot user
+     */
+    public boolean getBotUser() {
+        return this.botUser;
+    }
+
+    /**
+     * Retrieve latest set Slack team domain.
+     * @return String of slack team domain
+     */
+    public String getTeamDomain() {
+        return this.teamDomain;
+    }
+
+    /**
+     * Retrieve latest set Slack base URL.
+     * @return String of slack base URL
+     */
+    public String getBaseUrl() {
+        return this.baseUrl;
+    }
+
+    /**
+     * Retrieve latest set Slack channel.
+     * @return String of slack channel name
+     */
+    public String getRoom() {
+        return this.room;
+    }
+
+    /**
+     * Retrieve latest slack message text.
+     * @return String of slack message
+     */
+    public String getSlackMessageText() {
+        return this.slackMessageText;
+    }
+
+    /**
+     * Function to ensure Slack plugin is properly configured.
+     * @return Boolean true if configuration is valid, false otherwise
+     */
+    private boolean checkSlackConfigurationParams() {
+        if (room != null && !room.equals("")
+                && ((teamDomain != null && !teamDomain.equals("")) || (baseUrl != null && !baseUrl.equals("")))
+                && ((authToken != null && !authToken.equals(""))
+                        || (authTokenCredentialId != null && !authTokenCredentialId.equals(""))))  {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Function to report an error message to the plugin logs and to the build console.
+     * @param buildLog - PrintStream for current build log
+     * @param message - Extra message to append (if not null)
+     */
+    private void reportGenericErrorMessage(PrintStream buildLog, String message) {
+        StringBuilder s = new StringBuilder("Global Slack Notifier tried posting build failure to slack."
+                + " However some error occurred\n");
+        s.append("TeamDomain :" + teamDomain + "\n");
+        s.append("BaseUrl :" + baseUrl + "\n");
+        s.append("Channel :" + room + "\n");
+        s.append("BotUser:" + botUser);
+        if (message != null) {
+            s.append("\n"+message);
+        }
+
+        if (buildLog != null) {
+            buildLog.println("[BFA] Failed to send build failure information to slack.");
+            if (message != null) {
+                buildLog.println(message);
+            }
+        }
+
+        logger.log(Level.SEVERE, s.toString());
+    }
+
+    /**
+     * Function to send a slack message to a channel specificed in
+     * the plugin configuration. Uses all slack plugin settings except those
+     * that are overridden by the build failure analyzer plugin configurations (this plugin).
+     *
+     * @param messageText - Content of the slack message.
+     * @param buildLog - PrintStream of build to allow for success and error messages to be displayed.
+     * @return boolean true if message sent successfully, otherwise false
+     */
+    public boolean postToSlack(String messageText, PrintStream buildLog) {
+        slackMessageText = messageText;
+        String messageColor = "danger";
+        String useRoom;
+
+        String customSlackChannel = PluginImpl.getInstance().getSlackChannelName();
+        if (customSlackChannel.equals("")) {
+            // If no slack channel was specified in plugin settings,
+            // use channel specified in Global Slack Notifier Plugin settings
+            useRoom = this.room;
+        } else {
+            useRoom = customSlackChannel;
+        }
+
+        if (checkSlackConfigurationParams()) {
+            SlackService service = new StandardSlackService(baseUrl, teamDomain, authToken,
+                    authTokenCredentialId, botUser, useRoom);
+            boolean postResult = service.publish(messageText, messageColor);
+            if(!postResult){
+                reportGenericErrorMessage(buildLog, null);
+            } else {
+                if (buildLog != null) {
+                    buildLog.println("[BFA] Sent build failure information to slack.");
+                }
+            }
+            return true;
+        } else {
+            reportGenericErrorMessage(buildLog, "Slack Notifier plugin missing configurations.");
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
+++ b/src/main/java/com/sonyericsson/jenkins/plugins/bfa/model/FailureCause.java
@@ -159,6 +159,18 @@ public class FailureCause implements Serializable, Action, Describable<FailureCa
     }
 
     /**
+     * Standard constructor.
+     *
+     * @param name        the name of this FailureCause.
+     * @param description the description of this FailureCause.
+     * @param comment the comment for this FailureCause.
+     * @param categories    the categories of this FailureCause.
+     */
+    public FailureCause(String name, String description, String comment, String categories) {
+        this(null, name, description, "", null, Arrays.<String>asList(Util.tokenize(categories)), null, null);
+    }
+
+    /**
      * Default constructor. <strong>Do not use this unless you are a serializer.</strong>
      */
     public FailureCause() {

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.jelly
@@ -61,6 +61,22 @@
                  description="${%enableGerritTriggerDescription}">
             <f:checkbox name="gerritTriggerEnabled" checked="${it.gerritTriggerEnabled}" default="true"/>
         </f:entry>
+        <f:entry title="${%Send notifications to Slack}"
+                 description="${%enableSlackNotificationsDescription}">
+            <f:checkbox name="slackNotifEnabled" checked="${it.slackNotifEnabled}" default="false"/>
+        </f:entry>
+        <f:advanced>
+	    	<f:section title="${%Build failure analyzer - Slack options}">
+	            <f:entry title="${%Slack Channel}"
+	                     description="${%Slack channel to use for notification of build failures. Overrides slack channel specified in Global Slack Notifier settings. Ex:#build-failures }">
+	        		<f:textbox name="slackChannelName" value="${it.slackChannelName}" default="${it.DEFAULT_SLACK_CHANNEL}"/>
+	        	</f:entry>
+	        	<f:entry title="${%Failure Cause Categories}"
+	                     description="${%Instruct plugin to only notify slack channel of failures listed as part of a certain category. Use space-separated list. Default: ALL}">
+	                <f:textbox name="slackFailureCategories" value="${it.slackFailureCategories}" default="${it.DEFAULT_SLACK_FAILURE_CATEGORIES}"/>
+	        	</f:entry>
+	        </f:section>
+        </f:advanced>
         <f:entry title="${%Concurrent scans}"
                  description="${%nrOfScanThreadsDescription}">
             <f:textbox name="nrOfScanThreads" clazz="required positive-number" value="${it.nrOfScanThreads}"/>

--- a/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
+++ b/src/main/resources/com/sonyericsson/jenkins/plugins/bfa/PluginImpl/config.properties
@@ -1,4 +1,5 @@
 enableGerritTriggerDescription=This option allows BFA to forward the description of the found causes to the Gerrit-Trigger-plugin, ultimately allowing users to see their build issues directly inside Gerrit.
+enableSlackNotificationsDescription=This option allows BFA to forward specific categorized build failures (see Slack options below) to a slack channel (as specified below). Global Slack Notifier plugin must be installed.
 nrOfScanThreadsDescription=Number of threads per build to use when scanning the failed builds.
 testResultParsingEnabledDescription=Treat failed test cases (as indicated by JUnit/xUnit/... publishers) as failure causes.
 testResultCategoriesDescription=A space-separated list of categories to use for failure causes representing failed test cases.

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/PluginImplHudsonTest.java
@@ -258,6 +258,9 @@ public class PluginImplHudsonTest {
         form.put("globalEnabled", true);
         form.put("graphsEnabled", true);
         form.put("gerritTriggerEnabled", true);
+        form.put("slackNotifEnabled", true);
+        form.put("slackChannelName", PluginImpl.DEFAULT_SLACK_CHANNEL);
+        form.put("slackFailureCategories", PluginImpl.DEFAULT_SLACK_FAILURE_CATEGORIES);
         form.put("testResultParsingEnabled", true);
         form.put("testResultCategories", "foo bar");
         form.put("knowledgeBase", new JSONObject());

--- a/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
+++ b/src/test/java/com/sonyericsson/jenkins/plugins/bfa/SlackMessageProviderTest.java
@@ -1,0 +1,160 @@
+package com.sonyericsson.jenkins.plugins.bfa;
+
+import jenkins.model.Jenkins;
+import jenkins.plugins.slack.SlackNotifier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.http.ssl.SSLInitializationException;
+
+/**
+ * Tests for the SlackMessageProvider class.
+ * @author Johan Cornelissen &lt;j.cornelissen@queensu.ca&gt;
+ * @throws Exception if so.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PluginImpl.class, SlackNotifier.class, Jenkins.class})
+public class SlackMessageProviderTest {
+    private SlackNotifier slackPlugin;
+    private SlackNotifier.DescriptorImpl descriptor;
+    private static final String JENKINS_URL =  "http://some.jenkins.com";
+
+    /**
+     * Initialize basic stuff: Jenkins, PluginImpl, etc.
+     */
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(Jenkins.class);
+        Jenkins jenkins = PowerMockito.mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(jenkins.getRootUrl()).thenReturn(JENKINS_URL);
+
+        PowerMockito.mockStatic(SlackNotifier.class);
+        slackPlugin = PowerMockito.mock(SlackNotifier.class);
+
+        PowerMockito.mockStatic(PluginImpl.class);
+        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
+        PowerMockito.when(plugin.isSlackNotifEnabled()).thenReturn(true);
+        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
+        PowerMockito.when(PluginImpl.getInstance().getSlackChannelName()).thenReturn("");
+    }
+
+    /**
+     * Test to no slack message is sent if a slack channel is not provided.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testEmptyChannelSlackMessage() throws Exception {
+        boolean result = false;
+        try {
+            SlackMessageProvider slackTest = new SlackMessageProvider("team", "", "akasfahjfh", true, "", "");
+            result = slackTest.postToSlack("Some Message", null);
+        } catch (SSLInitializationException e) {
+          //SSL error indicates it tried to send to slack, so therefore was "successful"
+            result = true;
+        }
+
+        assertEquals(false, result);
+    }
+
+    /**
+     * Test to ensure a slack message can use baseUrl if no team domain is provided.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testEmptyTeamDomainSlackMessage() throws Exception {
+        boolean result = false;
+        try {
+            SlackMessageProvider slackTest = new SlackMessageProvider("", "team.slack.com", "akasfahjfh",
+                    true, "", "#some_channel");
+            result = slackTest.postToSlack("Some Message", null);
+        } catch (SSLInitializationException e) {
+          //SSL error indicates it tried to send to slack, so therefore was "successful"
+            result = true;
+        }
+
+        assertEquals(true, result);
+    }
+
+    /**
+     * Test to ensure a slack message can use team domain if no baseUrl is provided.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testEmptyBaseUrlSlackMessage() throws Exception {
+        boolean result = false;
+        try {
+            SlackMessageProvider slackTest = new SlackMessageProvider("team", "", "akasfahjfh",
+                    true, "", "#some_channel");
+            result = slackTest.postToSlack("Some Message", null);
+        } catch (SSLInitializationException e) {
+          //SSL error indicates it tried to send to slack, so therefore was "successful"
+            result = true;
+        }
+
+        assertEquals(true, result);
+    }
+
+    /**
+     * Test to ensure a slack message is not sent if both baseUrl and team domain are missing.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testEmptyBaseUrlAndTeamDomainSlackMessage() throws Exception {
+        boolean result = false;
+        try {
+            SlackMessageProvider slackTest = new SlackMessageProvider("", "", "akasfahjfh",
+                    true, "", "#some_channel");
+            result = slackTest.postToSlack("Some Message", null);
+        } catch (SSLInitializationException e) {
+          //SSL error indicates it tried to send to slack, so therefore was "successful"
+            result = true;
+        }
+
+        assertEquals(false, result);
+    }
+
+    /**
+     * Test to ensure a slack message is not sent if authtoken and authCredentialId is missing.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testMissingAuthSlackMessage() throws Exception {
+        boolean result = false;
+        try {
+            SlackMessageProvider slackTest = new SlackMessageProvider("", "team.slack.com", "",
+                    true, "", "#some_channel");
+            result = slackTest.postToSlack("Some Message", null);
+        } catch (SSLInitializationException e) {
+            //SSL error indicates it tried to send to slack, so therefore was "successful"
+            result = true;
+        }
+
+        assertEquals(false, result);
+    }
+
+    /**
+     * Test to ensure a slack message is sent if all necessary fields are supplied.
+     * @throws Exception if so.
+     */
+    @Test
+    public void testSuccessfulSlackMessage() throws Exception {
+        boolean result = false;
+        try {
+            SlackMessageProvider slackTest = new SlackMessageProvider("team", "", "akasfahjfh",
+                    true, "", "#some_channel");
+            result = slackTest.postToSlack("Some Message", null);
+        } catch (SSLInitializationException e) {
+            //SSL error indicates it tried to send to slack, so therefore was "successful"
+            result = true;
+        }
+        assertEquals(true, result);
+    }
+}


### PR DESCRIPTION
Commit adds Slack Notifications to the BFA plugin by making use of the Slack Notifier plugin.
By default,
-Slack notifications in BFA are turned off
-The slack channel specified in Slack Notifier will be used (if slack option enabled)
-All failure categories will be reported (if slack option enabled)

The BFA plugin settings now include:
-Toggle for turning on/off slack notifications
-Ability to specify which failure cause categories for which to notify.
-Ability to override the slack channel used for the BFA plugin

Unit tests were added in BuildFailureScannerHudsonTest for the areas of code added to the failure scanning.
As well as tests added to SlackMessageProviderTest for tests specific to the new class created.

With advanced menu not expanded:
![screen shot 2018-08-14 at 4 11 02 pm](https://user-images.githubusercontent.com/6536680/44115756-b2f56d88-9fdc-11e8-853d-b621602e6934.png)

With advanced menu expanded:
![screen shot 2018-08-14 at 4 11 11 pm](https://user-images.githubusercontent.com/6536680/44115755-b2d32516-9fdc-11e8-85b7-4cd3d6bd225f.png)